### PR TITLE
Add toggle on featured image to fallback to first image

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -239,6 +239,14 @@ export default function PostFeaturedImageEdit( {
 							/>
 						</>
 					) }
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Fallback to first image from post' ) }
+						onChange={ ( value ) =>
+							setAttributes( { useFirstImageFromPost: value } )
+						}
+						checked={ useFirstImageFromPost }
+					/>
 				</PanelBody>
 			</InspectorControls>
 		</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a toggle in the featured image settings to fallback to first image if no featured image is set

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Display an image for old blog post that do not have featured images.
Closes #39170

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Toggle sets the already existing attribute useFirstImageFromPost from the featured image block. (See #56573)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a new post with an image in it, but no Featured image.
2. Edit a template with a query block that contains a Featured image block.
3. Notice that the Query Block doesn't display any image in the Featured image block in the editor or the frontend.
4. Enable "Fallback to first image from post" in the featured image block settings.
5. Notice that the Query Block now displays the image in the Featured image block in the editor and the frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![fallbackfirstimage](https://github.com/user-attachments/assets/98f5ab2c-fff3-45a4-9e46-f9ac1f1ac829)

